### PR TITLE
Generic environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 *.retry
+inventory

--- a/environments/generic/README.md
+++ b/environments/generic/README.md
@@ -1,0 +1,11 @@
+Building N number of VMs:
+
+```
+VM_COUNT=3 vagrant up
+```
+
+Destroying:
+
+```
+VM_COUNT=3 vagrant destroy -f
+```

--- a/environments/generic/Vagrantfile
+++ b/environments/generic/Vagrantfile
@@ -4,8 +4,7 @@
 #   For generic purposes.
 
 Vagrant.configure("2") do |config|
-  N = ENV['VM_COUNT']
-  # N = 2
+  N = ENV['VM_COUNT'].to_i
   home = ENV['HOME']
   virtual_box_path = "#{home}/VirtualBox VMs"
   (1..N).each do |machine_id|

--- a/environments/generic/Vagrantfile
+++ b/environments/generic/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Description:
+#   For generic purposes.
+
+Vagrant.configure("2") do |config|
+  N = ENV['VM_COUNT']
+  # N = 2
+  home = ENV['HOME']
+  virtual_box_path = "#{home}/VirtualBox VMs"
+  (1..N).each do |machine_id|
+    hostname = "vm#{machine_id}"
+    config.vm.define "#{hostname}" do |machine|
+      machine.vm.hostname = "#{hostname}"
+      machine.vm.box = "centos/7"
+      machine.vm.network "private_network", ip: "192.168.50.#{100+machine_id}"
+      machine.vm.provider "virtualbox" do |vb|
+        vb.name = "#{hostname}"
+      end
+      # run ansible playbook on all machines when all of them are ready
+      if machine_id == N
+        machine.vm.provision :ansible do |ansible|
+          ansible.limit = "all"
+          ansible.playbook = "setup_base.yml"
+        end
+      end
+    end
+  end
+end

--- a/environments/generic/setup_base.yml
+++ b/environments/generic/setup_base.yml
@@ -1,0 +1,1 @@
+../../playbooks/setup_base.yml

--- a/environments/generic/spin_up_vms.sh
+++ b/environments/generic/spin_up_vms.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export VM_COUNT="$1"
-[ -z $VM_COUNT ] && { echo "Usage: $0 VM_COUNT"; exit 1; }
-vagrant up

--- a/environments/generic/spin_up_vms.sh
+++ b/environments/generic/spin_up_vms.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export VM_COUNT="$1"
+[ -z $VM_COUNT ] && { echo "Usage: $0 VM_COUNT"; exit 1; }
+vagrant up


### PR DESCRIPTION
This can be used when you wan to create ad-hoc VMs without specific initial purpose. For example you are planning to create a hadoop cluster but might later on change to a kafka/zookeeper cluster, you can create 3 VMs up-front using:

`VM_COUNT=3 vagrant up`