### PR TITLE
Fix IP ordering

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -63,7 +63,7 @@ def get_last_ip():
         for line in f.readlines():
             ip_list.extend(re.findall(subnet + '.[0-9]+', line.strip()))
     try:
-        last_ip = sorted(ip_list)[-1:][0]
+        last_ip = sorted(ip_list, key=lambda x: int(x.split('.')[3]))[-1:][0]
         last_host = last_ip.split('.')[-1:][0]
     except IndexError:
         last_host = '1'


### PR DESCRIPTION
This fixes the following issue.

During VM creation time, script detects all the recorded IP inside /etc/hosts and sort them in order to get the last IP. The new VM will have an IP that is equal to "last IP in /etc/hosts" + 1. If you have the following IP list:

`l = ['192.168.50.10', '192.168.50.2', '192.168.50.4', '192.168.50.5', '192.168.50.6', '192.168.50.7', '192.168.50.9']`

Script will sort it in this order.

`['192.168.50.10', '192.168.50.2', '192.168.50.4', '192.168.50.5', '192.168.50.6', '192.168.50.7', '192.168.50.9']`

That order is wrong ('192.168.50.10' is in the first item instead of last) since the script treat each item as a string.

To fix it, we need to define a custom key which is the aim of this pull request. After providing a custom key, the list of IP addresses is properly sorted now.

`['192.168.50.2', '192.168.50.4', '192.168.50.5', '192.168.50.6', '192.168.50.7', '192.168.50.9', '192.168.50.10']`