### PR TITLE
Ability to recreate environment using existing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Create a 4GB/2vCPU VM:
 ./bootstrap.py -e gitlab -c 2 -m 4096 --create
 ```
 
+Rebuilding an existing environment (uses existing IP and hostname upon creation):
+```
+./bootstrap.py -e postgresql --rebuild
+```
+
 ## Bootstrapping
 
 Each environment will be created under `environment/` directory and a common

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -22,6 +22,7 @@ parser = ArgumentParser(description='Setups environment using Vagrant/Ansible',
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--create', action='store_true', help='create env')
 group.add_argument('--destroy', action='store_true', help='destroy env')
+group.add_argument('--rebuild', action='store_true', help='rebuild env')
 parser.add_argument('-n', dest='num', default='1', help='number of VMs')
 parser.add_argument('-s', dest='net', default='192.168.50', help='VM subnet')
 parser.add_argument('-b', dest='box', default='centos/7', help='vagrant box')
@@ -39,6 +40,7 @@ env = args.env
 subnet = args.net
 create = args.create
 destroy = args.destroy
+rebuild = args.rebuild
 cpu = args.cpu
 mem = args.mem
 box_type = args.box
@@ -138,6 +140,20 @@ def create_environment():
             sys.exit(1)
 
 
+def rebuild_environment():
+    try:
+        os.chdir(work_dir)
+    except FileNotFoundError:
+        print('Unable to find environment. Create it first using --create')
+        sys.exit(1)
+    destroy_env = subprocess.call([vagrant_cmd, "destroy", "-f"])
+    create_env = subprocess.call([vagrant_cmd, "up"])
+    if create_env != 0 or destroy_env != 0:
+        print('Error rebuilding environment')
+        destroy_environment()
+        sys.exit(1)
+
+
 def check_requirements():
     global vagrant_cmd
     vagrant_cmd = get_vagrant_cmd()
@@ -155,3 +171,5 @@ if create:
     create_environment()
 if destroy:
     destroy_environment()
+if rebuild:
+    rebuild_environment()


### PR DESCRIPTION
By default if you recreate an environment via `--destroy` and `--create`, the VMs created might have different IPs because the script will look again in `/etc/hosts` to check the last IP allocated.

For example if you have ane existing environment called `jenkins` and the VMs under that environment doesn't fall as the last host entries in `/etc/hosts` such as in this manner:
```
192.168.50.9  jenkins-vm9  # VAGRANT: e05f2cd66c1951911f521a4819fbddaf (jenkins-vm9) / f7944e2b-d0e5-47f7-9879-cbbee9300a1c
192.168.50.11  jira-vm11  # VAGRANT: 4a380066787d834238e19d02c5e5281f (jira-vm11) / a338fa0d-485f-4cce-8dbd-bdc1c5097631
192.168.50.12  hygieia-vm12  # VAGRANT: 8f4285026a770826d8397d4702db68ab (hygieia-vm12) / 2055bc1d-47d7-4956-9f68-f98600760fc2
192.168.50.13  postgresql-vm13  # VAGRANT: e882377a039579376b39ffa717c4a11e (postgresql-vm13) / 0da3e91a-85c2-459f-bb36-7b6e4c540ab6
192.168.50.14  postgresql-vm14  # VAGRANT: b825aa2261a1b928e3b6532081885c3e (postgresql-vm14) / c7b2a4af-3e0f-4c35-89f2-4c6d203c79c0
```

Once you decided to recreate that environment, the VM created will have IP of `192.168.50.15` and hostname of `jenkins-vm15`. It will not use its previous IP and hostname which are `192.168.50.9` and `jenkins-vm9`. That is undesirable specially if you have an ansible inventory file that relies on the old IP and hostnames.

The goal of this pull request is to allow rebuilding an environment and still be able to use existing settings such as the VM IP address and hostname. To use this feature, apply `--rebuild` flag. Example:
```
./bootstrap.py -e postgresql --rebuild
```